### PR TITLE
proper shutdown in web3

### DIFF
--- a/src/web3/web3.erl
+++ b/src/web3/web3.erl
@@ -22,10 +22,8 @@ handle_call(_, _From, BlockNum) ->
   {reply, max(-1,BlockNum - 10), BlockNum}.
 
 
-%TODO figure out how to do this
-%handle_cast(Cmd, BlockNum) when Cmd == stop ->{stop, ok, BlockNum}.
-
-%% update the block state
+handle_cast(Cmd, BlockNum) when Cmd == stop ->
+  {stop, ok, BlockNum};
 handle_cast(NewBlockNum, _) ->
   %?debugMsg("handlecast"),
   {noreply, NewBlockNum}.

--- a/test/web3_test.erl
+++ b/test/web3_test.erl
@@ -4,8 +4,8 @@
 -include_lib("stdlib/include/assert.hrl").
 
 web3_test() ->
-  {ok, Pid} = gen_server:start_link(web3, [], []),
-  ?debugFmt("~p~n",[Pid]),
+  {ok, Pid} = gen_server:start(web3, [], []),
+  ?debugFmt("started web3 gen_server ~p~n",[Pid]),
   N1 = gen_server:call(Pid, []),
   ?assertEqual(-1, N1),
 
@@ -14,4 +14,6 @@ web3_test() ->
   N2 = gen_server:call(Pid, []),
   ?assertEqual(113, N2),
 
-  gen_server:cast(Pid, stop).
+  gen_server:cast(Pid, stop),
+  % give time for server to stop
+  timer:sleep(200).


### PR DESCRIPTION
eunit outputs a lot of annoying crash/error report text for actors that got killed. Test still passes. Not sure how to make it go away D:.